### PR TITLE
Fix plugin registered name at README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This repo was forked from https://github.com/dlackty/fluent-plugin-remote_syslog
 
 ```
 <match foo>
-  type remote_syslog
+  type kubernetes_remote_syslog
   host example.com
   port 514
   severity debug
@@ -27,7 +27,7 @@ UDP logs are limited to 1024 bytes which can truncate your logs. If you need to 
 
 ```
 <match foo>
-  type remote_syslog
+  type kubernetes_remote_syslog
   host example.com
   protocol tcp
   port 514


### PR DESCRIPTION
As declared at https://github.com/georgegoh/fluent-plugin-kubernetes_remote_syslog/blob/33d3dc5330e0a6edaed2b400f409701bb13316e4/lib/fluent/plugin/out_kubernetes_remote_syslog.rb#L7

The plugin name should be `kubernetes_remote_syslog ` instead of `remote_syslog `