### PR TITLE
Add support for enabling TLS on syslog server and specifying a custom ca and fix tests.

### DIFF
--- a/lib/fluent/plugin/out_kubernetes_remote_syslog.rb
+++ b/lib/fluent/plugin/out_kubernetes_remote_syslog.rb
@@ -16,7 +16,7 @@ module Fluent
     config_param :host,     :string
     config_param :port,     :integer, :default => 514
     config_param :protocol, :string,  :default => 'udp'
-    config_param :tls,      :boolean, :default => false
+    config_param :tls,      :string,  :default => 'false'
     config_param :ca_file,  :string,  :default => ''
 
     config_param :facility,     :string,  :default => "user"
@@ -48,7 +48,7 @@ module Fluent
         if @protocol.downcase == 'tcp'
           @loggers[tag] ||= RemoteSyslogSender::TcpSender.new(@host,
             @port,
-            tls: @tls,
+            tls: (@tls.to_s.downcase == 'true' ? true : false),
             ca_file: @ca_file,
             facility: @facility,
             severity: @severity,

--- a/lib/fluent/plugin/out_kubernetes_remote_syslog.rb
+++ b/lib/fluent/plugin/out_kubernetes_remote_syslog.rb
@@ -16,6 +16,8 @@ module Fluent
     config_param :host,     :string
     config_param :port,     :integer, :default => 514
     config_param :protocol, :string,  :default => 'udp'
+    config_param :tls,      :boolean, :default => false
+    config_param :ca_file,  :string,  :default => ''
 
     config_param :facility,     :string,  :default => "user"
     config_param :severity,     :string,  :default => "notice"
@@ -46,6 +48,8 @@ module Fluent
         if @protocol.downcase == 'tcp'
           @loggers[tag] ||= RemoteSyslogSender::TcpSender.new(@host,
             @port,
+            tls: @tls,
+            ca_file: @ca_file,
             facility: @facility,
             severity: @severity,
             packet_size: @packet_size,

--- a/test/plugin/out_remote_syslog.rb
+++ b/test/plugin/out_remote_syslog.rb
@@ -19,6 +19,7 @@ class RemoteSyslogOutputTest < MiniTest::Unit::TestCase
       port 5566
       severity debug
       tag minitest
+      tls true
     ]
 
     d.run do
@@ -39,6 +40,7 @@ class RemoteSyslogOutputTest < MiniTest::Unit::TestCase
     assert_equal 1, p.facility
     assert_equal "minitest", p.tag
     assert_equal 7, p.severity
+    assert_equal true, p.tls
   end
 
   def test_rewrite_tag


### PR DESCRIPTION
Hi!

In https://github.com/fluent/fluentd-kubernetes-daemonset/issues/271 there was a need for adding support for TLS when talking to a syslog server.
This PR implements the tls and ca_file attributes that will allow that.
Thanks for your review.

Joseph